### PR TITLE
Fixed wrong key name in ownerinfo crd sample

### DIFF
--- a/config/samples/v1_ownerinfo.yaml
+++ b/config/samples/v1_ownerinfo.yaml
@@ -59,7 +59,7 @@ spec:
         address:
         city: Apeldoorn
         stateorprovince:
-        postalcode:
+        postcode:
         country: Netherlands
       contactvoicetelephone:
       contactfacsimiletelephone:


### PR DESCRIPTION
# Description

_What_ have you changed and _why_?

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR