### PR TITLE
new label function

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -87,6 +87,18 @@ func FinalizeIfNecessary(ctx context.Context, c client.Client, obj client.Object
 	return false, err
 }
 
+// CombineLabels combines multiple sets of labels into one set of labels
+// if a label key exists in multiple labelSets, the value of last labelSet with that key will be returned
+func CombineLabels(labelSets ...map[string]string) map[string]string {
+	labels := make(map[string]string)
+	for _, labelSet := range labelSets {
+		maps.Copy(labels, labelSet)
+	}
+	return labels
+}
+
+// SetImmutableLabels
+// Deprecated: immutability check can cause conflicts with external mutators, use CombineLabels instead
 func SetImmutableLabels(c client.Client, obj client.Object, labels map[string]string) error {
 	objLabels := obj.GetLabels()
 	if obj.GetResourceVersion() != "" || len(objLabels) > 0 {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -98,6 +98,7 @@ func CombineLabels(labelSets ...map[string]string) map[string]string {
 }
 
 // SetImmutableLabels
+//
 // Deprecated: immutability check can cause conflicts with external mutators, use CombineLabels instead
 func SetImmutableLabels(c client.Client, obj client.Object, labels map[string]string) error {
 	objLabels := obj.GetLabels()


### PR DESCRIPTION
# Description

SetImmutableLabels() causes issues with external mutators that patch in labels outside the operators.

The new CombineLabels() function gives operator generic functionality to create a set of labels based on multiple inputs
for setting labels on resources, the input will typically be (obj.Labels, cr.Labels, defaultLabels), combining the resources existing labels, with the cr Labels and a set of operator specific defaultLabels.

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR